### PR TITLE
🔧 Ignore Jest config file when building TypeScript sources

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "**/*spec.ts", "**/*.test.ts"],
+  "exclude": ["dist", "jest.config.ts", "**/*spec.ts", "**/*.test.ts"],
   "compilerOptions": {
     "sourceMap": false,
     "incremental": false


### PR DESCRIPTION
#2 added the `jest.config.ts` file to the root of the repository, which caused the hierarchy of the output folder (`./dist`) to change. This fixes it by ignoring the configuration file when compiling.