### PR TITLE
🔧 Fix Jest configuration

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,5 @@
 export default {
   clearMocks: true,
-  collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
   coverageProvider: 'v8',
   rootDir: 'src',


### PR DESCRIPTION
Explicitly setting `collectCoverageFrom` to all JavaScript and TypeScript files includes the index files, which is not wanted.

### Commits

- 🔧 Remove unneeded collectCoverageFrom setting collecting index files