### PR TITLE
✅ Fix configuration test

### DIFF
--- a/src/context/configuration.spec.ts
+++ b/src/context/configuration.spec.ts
@@ -261,7 +261,7 @@ describe('configuration', () => {
 
       const actualPaths = await listProjectPaths(tmpDir);
 
-      expect(actualPaths).toEqual([
+      expect(actualPaths).toContainAllValues([
         join(tmpDir, 'project1'),
         join(tmpDir, 'project2'),
       ]);


### PR DESCRIPTION
The title says it all.

### Commits

- ✅ Do not enforce order when testing returned project path