### PR TITLE
✨ Fetch entire configuration from `WorkspaceContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Features:
+
+- Make `WorkspaceContext.get[AndRender]()` accept no argument to retrieve the entire configuration.
+
 ## v0.11.0 (2023-07-24)
 
 Features:

--- a/src/context/configuration.ts
+++ b/src/context/configuration.ts
@@ -297,11 +297,13 @@ export type TypedWorkspaceConfiguration<C extends object> = {
    * Returns the value at a given path in the configuration.
    *
    * @param path The path to the value in the configuration object.
+   *  If the path is not specified, the whole configuration is returned.
    * @returns The value, or `undefined` if the path does not exist.
    */
-  get: <TPath extends string>(
+  get: (<TPath extends string>(
     path: TPath,
-  ) => GetFieldType<BaseConfiguration & C, TPath>;
+  ) => GetFieldType<BaseConfiguration & C, TPath>) &
+    (() => BaseConfiguration & C);
 
   /**
    * Returns the value at a given path in the configuration, or throws an error if the path does not exist.
@@ -318,11 +320,13 @@ export type TypedWorkspaceConfiguration<C extends object> = {
    * templates.
    *
    * @param path The path to the value in the configuration object.
+   *  If the path is not specified, the whole configuration is returned.
    * @returns The value after rendering.
    */
-  getAndRender: <TPath extends string>(
+  getAndRender: (<TPath extends string>(
     path: TPath,
-  ) => Promise<GetFieldType<BaseConfiguration & C, TPath>>;
+  ) => Promise<GetFieldType<BaseConfiguration & C, TPath>>) &
+    (() => Promise<BaseConfiguration & C>);
 
   /**
    * Renders the value at a given path in the configuration object, by recursively walking the value and processing

--- a/src/context/context.spec.ts
+++ b/src/context/context.spec.ts
@@ -71,6 +71,22 @@ describe('WorkspaceContext', () => {
       expect(() => actualContext.getOrThrow('🙅')).toThrow(
         ConfigurationValueNotFoundError,
       );
+      expect(actualContext.get()).toEqual({
+        workspace: { name: 'my-workspace' },
+        project: { name: 'my-project', type: '🐍', language: '🇫🇷' },
+        environments: {
+          dev: { name: 'Dev', configuration: { myService: { myValue: '🎉' } } },
+        },
+        myService: { myValue: '🎉' },
+      });
+      expect(await actualContext.getAndRender()).toEqual({
+        workspace: { name: 'my-workspace' },
+        project: { name: 'my-project', type: '🐍', language: '🇫🇷' },
+        environments: {
+          dev: { name: 'Dev', configuration: { myService: { myValue: '🎉' } } },
+        },
+        myService: { myValue: '🎉' },
+      });
       expect(actualAdditionalDirectories).toBeEmpty();
     });
 

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -164,6 +164,13 @@ export class WorkspaceContext {
   }
 
   /**
+   * Returns the entire configuration for the current context.
+   *
+   * @returns The configuration.
+   */
+  get(): BaseConfiguration;
+
+  /**
    * Returns the value at a given path in the configuration.
    *
    * @param path The path to the value in the configuration object.
@@ -171,8 +178,10 @@ export class WorkspaceContext {
    */
   get<TPath extends string>(
     path: TPath,
-  ): GetFieldType<BaseConfiguration, TPath> {
-    return this.configuration.get(path);
+  ): GetFieldType<BaseConfiguration, TPath>;
+
+  get(path?: string): any {
+    return this.configuration.get(path as any);
   }
 
   /**
@@ -188,18 +197,27 @@ export class WorkspaceContext {
   }
 
   /**
+   * Returns the entire configuration for the current context, after rendering all templates.
+   *
+   * @returns The rendered configuration.
+   */
+  getAndRender(): Promise<BaseConfiguration>;
+
+  /**
    * Renders the value at a given path in the configuration object, by recursively walking the value and processing
    * templates.
    *
    * @param path The path to the value in the configuration object.
    * @returns The value after rendering.
    */
-  async getAndRender<TPath extends string>(
+  getAndRender<TPath extends string>(
     path: TPath,
-  ): Promise<GetFieldType<BaseConfiguration, TPath>> {
+  ): Promise<GetFieldType<BaseConfiguration, TPath>>;
+
+  async getAndRender(path?: string): Promise<any> {
     return await this.configuration.getAndRender(
       { secret: (secretId: string) => this.secret(secretId) },
-      path,
+      path as any,
     );
   }
 


### PR DESCRIPTION
This PR makes `WorkspaceContext.get[AndRender]()` accept no argument to retrieve the entire configuration.

### Commits

- ✨ Allow accessing the entire configuration from the workspace context
- 📝 Update changelog