### PR TITLE
🔖 Prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.12.0 (2023-07-24)
+
 Features:
 
 - Make `WorkspaceContext.get[AndRender]()` accept no argument to retrieve the entire configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.14.195",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Provides the base functionalities for a workspace: configuration loading and registering functions.",
   "repository": "github:causa-io/workspace",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Make `WorkspaceContext.get[AndRender]()` accept no argument to retrieve the entire configuration.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.12.0