### PR TITLE
⬆️ Node.js 20 support and drop for 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Breaking change:
+
+- Drop support for Node.js 16.
+
 Chore:
 
 - Upgrade dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "semver": "^7.6.2"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
+        "@tsconfig/node20": "^20.1.4",
         "@types/jest": "^29.5.12",
         "@types/js-yaml": "^4.0.9",
         "@types/lodash-es": "^4.17.12",
@@ -1476,10 +1476,10 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
+      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
       "dev": true
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "ISC",
   "type": "module",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "semver": "^7.6.2"
   },
   "devDependencies": {
-    "@tsconfig/node18": "^18.2.4",
+    "@tsconfig/node20": "^20.1.4",
     "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.9",
     "@types/lodash-es": "^4.17.12",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "node16",
     "declaration": true,
     "removeComments": false,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
The title says it all.

### Commits

- **🔧 Update Node.js engine requirement**
- **⬆️ Upgrade TypeScript configuration and remove redundant fields**
- **📝 Update changelog**