### PR TITLE
🔖 Prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.13.0 (2024-05-17)
+
 Breaking change:
 
 - Drop support for Node.js 16.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Provides the base functionalities for a workspace: configuration loading and registering functions.",
   "repository": "github:causa-io/workspace",
   "license": "ISC",


### PR DESCRIPTION
Breaking change:

- Drop support for Node.js 16.

Chore:

- Upgrade dependencies.

### Commits

- **🔖 Set version to 0.13.0**
- **📝 Update changelog**