### PR TITLE
💥 Ignore symlinks in file-related operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Do not follow symlinks when looking for additional project directories and in the `listFilesAndFormat` utility.
+
 ## v0.14.0 (2024-05-24)
 
 Breaking change:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Provides the base functionalities for a workspace: configuration loading and registering functions.",
   "repository": "github:causa-io/workspace",
   "license": "ISC",

--- a/src/context/context.spec.ts
+++ b/src/context/context.spec.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from 'fs/promises';
+import { mkdir, mkdtemp, rm, symlink } from 'fs/promises';
 import 'jest-extended';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
@@ -111,7 +111,7 @@ describe('WorkspaceContext', () => {
       );
     });
 
-    it('should return project additional directories', async () => {
+    it('should return project additional directories and not follow symlinks', async () => {
       const workspaceConfiguration: PartialConfiguration<BaseConfiguration> = {
         workspace: { name: 'my-workspace' },
       };
@@ -144,6 +144,10 @@ describe('WorkspaceContext', () => {
       await mkdir(join(firstAdditionalDir, 'some-dir'), { recursive: true });
       await mkdir(secondAdditionalDir, { recursive: true });
       await mkdir(join(tmpDir, 'nope'), { recursive: true });
+      await symlink(
+        join(tmpDir, 'domain', 'my-domain'),
+        join(tmpDir, 'domain', 'symlink'),
+      );
       const expectedProjectDir = join(tmpDir, 'project');
       const expectedAdditionalDirectories = [
         firstAdditionalDir,

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -128,6 +128,7 @@ export class WorkspaceContext {
       gitignore: true,
       onlyDirectories: true,
       cwd: this.rootPath,
+      followSymbolicLinks: false,
     });
 
     this.logger.debug(

--- a/src/file-utils.spec.ts
+++ b/src/file-utils.spec.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'fs/promises';
 import 'jest-extended';
 import { join, resolve } from 'path';
 import { listFilesAndFormat } from './file-utils.js';
@@ -25,6 +25,10 @@ describe('file-utils', () => {
       await writeFile(join(tmpDir, 'allowed2/third.test'), '🎁');
       await writeFile(join(tmpDir, 'allowed2/nope.other'), '🎁');
       await writeFile(join(tmpDir, 'nope/no.test'), '🎁');
+      await symlink(
+        join(tmpDir, 'allowed1/second.test'),
+        join(tmpDir, 'allowed1/nope.test'),
+      );
 
       const actualMatches = await listFilesAndFormat(
         ['allowed1/**/*.test', 'allowed2/*.test'],

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -25,6 +25,7 @@ export type FormattedMatchedFile = {
 /**
  * Lists files using the given globs, extracts information from the paths, and renders a string using the provided
  * template.
+ * It does not follow symbolic links by default.
  *
  * @param globs The glob pattern used to find the files.
  * @param regExp The regular expression matched against the found file paths.
@@ -39,7 +40,12 @@ export async function listFilesAndFormat(
   regExp: string | RegExp,
   format: string,
   rootPath: string,
-  options: { nonMatchingPathHandler?: (path: string) => void } & Options = {},
+  options: {
+    /**
+     * A function called when a path found using glob patterns does not match the regular expression.
+     */
+    nonMatchingPathHandler?: (path: string) => void;
+  } & Options = {},
 ): Promise<FormattedMatchedFile[]> {
   const { nonMatchingPathHandler, ...globbyOptions } = options;
 
@@ -47,6 +53,7 @@ export async function listFilesAndFormat(
 
   const paths = await globby(globs, {
     gitignore: true,
+    followSymbolicLinks: false,
     ...globbyOptions,
     cwd: rootPath,
   });


### PR DESCRIPTION
This follows #50 for other `globby` usages. This ensures recursive symlinks aren't a problem in a workspace.

### Commits

- **💥 Do not follow symbolic links by default in listFilesAndFormat**
- **💥 Do not follow symlinks when listing additional project directories**
- **🔖 Set version to 0.15.0**
- **📝 Update changelog**