### PR TITLE
💥 Rework the `project.additionalDirectories` configuration to allow for files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Rename the `project.additionalDirectories` configuration to `project.externalFiles`.
+- Rename `WorkspaceContext.getProjectAdditionalDirectories` to `getProjectExternalPaths` to handle files and / or directories.
+
 ## v0.15.0 (2024-05-27)
 
 Breaking changes:

--- a/src/context/base-configuration.ts
+++ b/src/context/base-configuration.ts
@@ -47,13 +47,13 @@ export type BaseConfiguration = {
     readonly language: string;
 
     /**
-     * A list of glob patterns, relative to the **workspace** root, that match directories that are also part of the
-     * project.
-     * This is only needed for directories that are not part of the project root. This is a hint to various processes
-     * (e.g. the continuous integration) that they should also consider these directories when running operations
-     * against the project.
+     * A list of glob patterns, relative to the **workspace** root, that match files or directories that are also part
+     * of the project.
+     * This is only needed for files or directories that are not part of the project root.
+     * This is a hint to various processes (e.g. project changes detection, linting, etc.) that they should also
+     * consider those files and directories when running operations against the project.
      */
-    readonly additionalDirectories?: string[];
+    readonly externalFiles?: string[];
   };
 
   /**

--- a/src/context/context.spec.ts
+++ b/src/context/context.spec.ts
@@ -60,7 +60,7 @@ describe('WorkspaceContext', () => {
         environment: 'dev',
       });
       const actualAdditionalDirectories =
-        await actualContext.getProjectAdditionalDirectories();
+        await actualContext.getProjectExternalDirectories();
 
       expect(actualContext.workingDirectory).toEqual(expectedProjectDir);
       expect(actualContext.rootPath).toEqual(tmpDir);
@@ -111,7 +111,7 @@ describe('WorkspaceContext', () => {
       );
     });
 
-    it('should return project additional directories and not follow symlinks', async () => {
+    it('should return project external directories and not follow symlinks', async () => {
       const workspaceConfiguration: PartialConfiguration<BaseConfiguration> = {
         workspace: { name: 'my-workspace' },
       };
@@ -120,7 +120,7 @@ describe('WorkspaceContext', () => {
           name: 'my-project',
           type: '🐍',
           language: '🇫🇷',
-          additionalDirectories: ['domain/*/sub-path'],
+          externalFiles: ['domain/*/sub-path'],
         },
       };
       await writeConfiguration(tmpDir, './causa.yaml', workspaceConfiguration);
@@ -158,7 +158,7 @@ describe('WorkspaceContext', () => {
         workingDirectory: expectedProjectDir,
       });
       const actualAdditionalDirectories =
-        await actualContext.getProjectAdditionalDirectories();
+        await actualContext.getProjectExternalDirectories();
 
       expect(actualContext.workingDirectory).toEqual(expectedProjectDir);
       expect(actualContext.rootPath).toEqual(tmpDir);

--- a/src/context/context.spec.ts
+++ b/src/context/context.spec.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, symlink } from 'fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'fs/promises';
 import 'jest-extended';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
@@ -59,8 +59,7 @@ describe('WorkspaceContext', () => {
         workingDirectory: expectedProjectDir,
         environment: 'dev',
       });
-      const actualAdditionalDirectories =
-        await actualContext.getProjectExternalDirectories();
+      const actualExternalPaths = await actualContext.getProjectExternalPaths();
 
       expect(actualContext.workingDirectory).toEqual(expectedProjectDir);
       expect(actualContext.rootPath).toEqual(tmpDir);
@@ -87,7 +86,7 @@ describe('WorkspaceContext', () => {
         },
         myService: { myValue: '🎉' },
       });
-      expect(actualAdditionalDirectories).toBeEmpty();
+      expect(actualExternalPaths).toBeEmpty();
     });
 
     it('should throw when the project and environment are not set', async () => {
@@ -110,7 +109,9 @@ describe('WorkspaceContext', () => {
         EnvironmentNotSetError,
       );
     });
+  });
 
+  describe('getProjectExternalPaths', () => {
     it('should return project external directories and not follow symlinks', async () => {
       const workspaceConfiguration: PartialConfiguration<BaseConfiguration> = {
         workspace: { name: 'my-workspace' },
@@ -129,43 +130,65 @@ describe('WorkspaceContext', () => {
         './project/causa.yaml',
         projectConfiguration,
       );
-      const firstAdditionalDir = join(
-        tmpDir,
-        'domain',
-        'my-domain',
-        'sub-path',
-      );
-      const secondAdditionalDir = join(
+      const firstExternalDir = join(tmpDir, 'domain', 'my-domain', 'sub-path');
+      const secondExternalDir = join(
         tmpDir,
         'domain',
         'other-domain',
         'sub-path',
       );
-      await mkdir(join(firstAdditionalDir, 'some-dir'), { recursive: true });
-      await mkdir(secondAdditionalDir, { recursive: true });
+      await mkdir(join(firstExternalDir, 'some-dir'), { recursive: true });
+      await mkdir(secondExternalDir, { recursive: true });
       await mkdir(join(tmpDir, 'nope'), { recursive: true });
       await symlink(
         join(tmpDir, 'domain', 'my-domain'),
         join(tmpDir, 'domain', 'symlink'),
       );
       const expectedProjectDir = join(tmpDir, 'project');
-      const expectedAdditionalDirectories = [
-        firstAdditionalDir,
-        secondAdditionalDir,
-      ];
+      const expectedExternalPaths = [firstExternalDir, secondExternalDir];
 
       const actualContext = await WorkspaceContext.init({
         workingDirectory: expectedProjectDir,
       });
-      const actualAdditionalDirectories =
-        await actualContext.getProjectExternalDirectories();
+      const actualExternalPaths = await actualContext.getProjectExternalPaths({
+        onlyDirectories: true,
+      });
 
-      expect(actualContext.workingDirectory).toEqual(expectedProjectDir);
-      expect(actualContext.rootPath).toEqual(tmpDir);
-      expect(actualContext.projectPath).toEqual(expectedProjectDir);
-      expect(actualAdditionalDirectories).toContainAllValues(
-        expectedAdditionalDirectories,
+      expect(actualExternalPaths).toContainAllValues(expectedExternalPaths);
+    });
+
+    it('should return project external files and directories', async () => {
+      const workspaceConfiguration: PartialConfiguration<BaseConfiguration> = {
+        workspace: { name: 'my-workspace' },
+      };
+      const projectConfiguration: PartialConfiguration<BaseConfiguration> = {
+        project: {
+          name: 'my-project',
+          type: '🐍',
+          language: '🇫🇷',
+          externalFiles: ['dir1', 'file1.*'],
+        },
+      };
+      await writeConfiguration(tmpDir, './causa.yaml', workspaceConfiguration);
+      await writeConfiguration(
+        tmpDir,
+        './project/causa.yaml',
+        projectConfiguration,
       );
+      const externalDir = join(tmpDir, 'dir1');
+      await mkdir(externalDir, { recursive: true });
+      await mkdir(join(tmpDir, 'nope'), { recursive: true });
+      const externalFile = join(tmpDir, 'file1.txt');
+      await writeFile(externalFile, '🎉');
+      const workingDirectory = join(tmpDir, 'project');
+      const expectedExternalPaths = [externalDir, externalFile];
+
+      const actualContext = await WorkspaceContext.init({ workingDirectory });
+      const actualExternalPaths = await actualContext.getProjectExternalPaths({
+        onlyFiles: false,
+      });
+
+      expect(actualExternalPaths).toContainAllValues(expectedExternalPaths);
     });
   });
 

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -116,18 +116,19 @@ export class WorkspaceContext {
   }
 
   /**
-   * Lists the additional directories belonging to the current project, based on the `project.additionalDirectories`
-   * configuration.
+   * Lists the external directories belonging to the current project, based on the `project.externalDirectories`
+   * configuration. This only returns directories that match one of the glob patterns, not directories that contain
+   * files matching the patterns.
    *
-   * @returns The list of additional directories that are part of the project.
+   * @returns The list of external directories that are part of the project.
    */
-  async getProjectAdditionalDirectories(): Promise<string[]> {
-    const additionalDirectories = this.get('project.additionalDirectories');
-    if (!additionalDirectories || additionalDirectories.length === 0) {
+  async getProjectExternalDirectories(): Promise<string[]> {
+    const externalFiles = this.get('project.externalFiles');
+    if (!externalFiles || externalFiles.length === 0) {
       return [];
     }
 
-    const additionalPaths = await globby(additionalDirectories, {
+    const additionalPaths = await globby(externalFiles, {
       gitignore: true,
       onlyDirectories: true,
       cwd: this.rootPath,

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,5 +1,5 @@
-import { globby } from 'globby';
-import { join, resolve } from 'path';
+import { globby, type Options } from 'globby';
+import { resolve } from 'path';
 import { type Logger, pino } from 'pino';
 import type { GetFieldType } from '../configuration/index.js';
 import {
@@ -12,11 +12,11 @@ import {
 import { ServiceCache } from '../service-cache/index.js';
 import type { BaseConfiguration } from './base-configuration.js';
 import {
-  type TypedWorkspaceConfiguration,
-  type WorkspaceConfiguration,
   listProjectPaths,
   loadWorkspaceConfiguration,
   makeProcessorConfiguration,
+  type TypedWorkspaceConfiguration,
+  type WorkspaceConfiguration,
 } from './configuration.js';
 import {
   ContextNotAProjectError,
@@ -116,32 +116,35 @@ export class WorkspaceContext {
   }
 
   /**
-   * Lists the external directories belonging to the current project, based on the `project.externalDirectories`
-   * configuration. This only returns directories that match one of the glob patterns, not directories that contain
-   * files matching the patterns.
+   * Lists the external files or directories belonging to the current project, based on the `project.externalFiles`
+   * configuration.
    *
+   * @param options Options to filter the results. By default, only files are returned.
    * @returns The list of external directories that are part of the project.
    */
-  async getProjectExternalDirectories(): Promise<string[]> {
+  async getProjectExternalPaths(
+    options: Pick<Options, 'onlyDirectories' | 'onlyFiles'> = {},
+  ): Promise<string[]> {
     const externalFiles = this.get('project.externalFiles');
     if (!externalFiles || externalFiles.length === 0) {
       return [];
     }
 
-    const additionalPaths = await globby(externalFiles, {
+    const externalPaths = await globby(externalFiles, {
       gitignore: true,
-      onlyDirectories: true,
       cwd: this.rootPath,
       followSymbolicLinks: false,
+      absolute: true,
+      ...options,
     });
 
     this.logger.debug(
-      `📂 Found additional directories for the project in the configuration: ${additionalPaths
+      `📂 Found external paths for the project in the configuration: ${externalPaths
         .map((p) => `'${p}'`)
         .join(', ')}.`,
     );
 
-    return additionalPaths.map((p) => join(this.rootPath, p));
+    return externalPaths;
   }
 
   /**


### PR DESCRIPTION
The title says it all. The reason for this change is that the glob patterns in this configuration don't have to match directories, files could be accepted as well. Allowing files makes the configuration more flexible and allow for more use cases in workspace modules.

### Commits

- **💥 Rename the project.additionalDirectories configuration to project.externalFiles**
- **💥 Rename WorkspaceContext.getProjectExternalPaths to handle files and / or directories**
- **📝 Update changelog**