### PR TITLE
🔖 Prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.16.0 (2024-10-07)
+
 Breaking changes:
 
 - Rename the `project.additionalDirectories` configuration to `project.externalFiles`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Provides the base functionalities for a workspace: configuration loading and registering functions.",
   "repository": "github:causa-io/workspace",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Rename the `project.additionalDirectories` configuration to `project.externalFiles`.
- Rename `WorkspaceContext.getProjectAdditionalDirectories` to `getProjectExternalPaths` to handle files and / or directories.

### Commits

- **🔖 Set version to 0.16.0**
- **📝 Update changelog**