### PR TITLE
🔖 Prepare v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.17.0 (2025-08-05)
+
 Breaking changes:
 
 - Upgrade the minimum Node.js version to `20`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Provides the base functionalities for a workspace: configuration loading and registering functions.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Upgrade the minimum Node.js version to `20`.

Features:

- Support the `unsafe` option for `ConfigurationReader.get`.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- [x] 📝 Documentation has been updated.