### PR TITLE
✨ `ConfigurationGetOptions` for `WorkspaceContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Features:
+
+- Support `ConfigurationGetOptions` in `ConfigurationReader.getOrThrow`.
+- Expose `ConfigurationGetOptions` in `WorkspaceContext` configuration methods.
+
 ## v0.17.0 (2025-08-05)
 
 Breaking changes:

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -4,6 +4,7 @@ export {
   ConfigurationReaderSourceType,
 } from './reader.js';
 export type {
+  ConfigurationGetOptions,
   GetFieldType,
   PartialConfiguration,
   RawConfiguration,

--- a/src/configuration/reader.spec.ts
+++ b/src/configuration/reader.spec.ts
@@ -147,6 +147,22 @@ describe('ConfigurationReader', () => {
         ConfigurationValueNotFoundError,
       );
     });
+
+    it('should not throw an error when unsafe option is true', () => {
+      const readerWithTemplate = reader.mergedWith({
+        sourceType: ConfigurationReaderSourceType.File,
+        source: 'template-file.json',
+        configuration: {
+          setting1: { [TEMPLATE_KEY]: 'some template' } as any,
+        },
+      });
+
+      const actualValue = readerWithTemplate.getOrThrow('setting1', {
+        unsafe: true,
+      });
+
+      expect(actualValue).toEqual({ [TEMPLATE_KEY]: 'some template' });
+    });
   });
 
   describe('getAndRender', () => {

--- a/src/configuration/reader.ts
+++ b/src/configuration/reader.ts
@@ -261,12 +261,14 @@ export class ConfigurationReader<T extends object> {
    * Returns the value at a given path in the configuration object, or throws an error if the path does not exist.
    *
    * @param path The path to the value in the configuration object.
+   * @param options Optional options for the get operation.
    * @returns The value in the configuration.
    */
   getOrThrow<TPath extends string>(
     path: TPath,
+    options?: ConfigurationGetOptions,
   ): Exclude<GetFieldType<T, TPath>, undefined> {
-    const value = this.get(path);
+    const value = this.get(path, options);
     if (value === undefined) {
       throw new ConfigurationValueNotFoundError(path);
     }

--- a/src/context/configuration.ts
+++ b/src/context/configuration.ts
@@ -7,6 +7,7 @@ import type { Logger } from 'pino';
 import {
   ConfigurationReader,
   ConfigurationReaderSourceType,
+  type ConfigurationGetOptions,
   type GetFieldType,
   type PartialConfiguration,
   type RawConfiguration,
@@ -297,11 +298,12 @@ export type TypedWorkspaceConfiguration<C extends object> = {
    * Returns the value at a given path in the configuration.
    *
    * @param path The path to the value in the configuration object.
-   *  If the path is not specified, the whole configuration is returned.
+   * @param options Optional options for the get operation.
    * @returns The value, or `undefined` if the path does not exist.
    */
   get: (<TPath extends string>(
     path: TPath,
+    options?: ConfigurationGetOptions,
   ) => GetFieldType<BaseConfiguration & C, TPath>) &
     (() => BaseConfiguration & C);
 
@@ -309,10 +311,12 @@ export type TypedWorkspaceConfiguration<C extends object> = {
    * Returns the value at a given path in the configuration, or throws an error if the path does not exist.
    *
    * @param path The path to the value in the configuration object.
+   * @param options Optional options for the get operation.
    * @returns The value in the configuration.
    */
   getOrThrow: <TPath extends string>(
     path: TPath,
+    options?: ConfigurationGetOptions,
   ) => Exclude<GetFieldType<BaseConfiguration & C, TPath>, undefined>;
 
   /**

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -1,7 +1,10 @@
 import { globby, type Options } from 'globby';
 import { resolve } from 'path';
 import { type Logger, pino } from 'pino';
-import type { GetFieldType } from '../configuration/index.js';
+import type {
+  ConfigurationGetOptions,
+  GetFieldType,
+} from '../configuration/index.js';
 import {
   FunctionRegistry,
   type ImplementableFunctionArguments,
@@ -174,34 +177,42 @@ export class WorkspaceContext {
   /**
    * Returns the entire configuration for the current context.
    *
+   * @param options Optional options for the get operation.
    * @returns The configuration.
    */
-  get(): BaseConfiguration;
+  get(options?: ConfigurationGetOptions): BaseConfiguration;
 
   /**
    * Returns the value at a given path in the configuration.
    *
    * @param path The path to the value in the configuration object.
+   * @param options Optional options for the get operation.
    * @returns The value, or `undefined` if the path does not exist.
    */
   get<TPath extends string>(
     path: TPath,
+    options?: ConfigurationGetOptions,
   ): GetFieldType<BaseConfiguration, TPath>;
 
-  get(path?: string): any {
-    return this.configuration.get(path as any);
+  get(
+    pathOrOptions?: string | ConfigurationGetOptions,
+    options?: ConfigurationGetOptions,
+  ): any {
+    return this.configuration.get(pathOrOptions as any, options);
   }
 
   /**
    * Returns the value at a given path in the configuration, or throws an error if the path does not exist.
    *
    * @param path The path to the value in the configuration object.
+   * @param options Optional options for the get operation.
    * @returns The value in the configuration.
    */
   getOrThrow<TPath extends string>(
     path: TPath,
+    options?: ConfigurationGetOptions,
   ): Exclude<GetFieldType<BaseConfiguration, TPath>, undefined> {
-    return this.configuration.getOrThrow(path);
+    return this.configuration.getOrThrow(path, options);
   }
 
   /**


### PR DESCRIPTION
### 📝 Description of the PR

This adds #61 to `getOrThrow` and the counterparts in `WorkspaceContext`.
This should have been a single PR.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.