### PR TITLE
✨ Add `callAll` method to invoke all matching function implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Features:
 
 - Add the `project.description` to the configuration schema.
+- Provide `callAll` on the `FunctionRegistry` and `WorkspaceContext`.
 
 ## v0.21.1 (2026-02-09)
 

--- a/src/context/context.spec.ts
+++ b/src/context/context.spec.ts
@@ -466,6 +466,16 @@ describe('WorkspaceContext', () => {
       expect(actualDefinitions).toEqual([MyFunction]);
     });
 
+    it('should call all function implementations', async () => {
+      const context = await WorkspaceContext.init({
+        workingDirectory: tmpDir,
+      });
+
+      const actualResults = context.callAll(MyFunction, {});
+
+      expect(actualResults).toEqual(['🎉']);
+    });
+
     it('should return function implementations', async () => {
       const context = await WorkspaceContext.init({
         workingDirectory: tmpDir,

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -306,6 +306,21 @@ export class WorkspaceContext {
   }
 
   /**
+   * Looks up a function definition and calls all corresponding implementations that support this context, returning
+   * the results as an array.
+   *
+   * @param definition The constructor of the abstract class defining the function.
+   * @param args Arguments to pass to the function.
+   * @returns The results of the function calls.
+   */
+  callAll<D extends WorkspaceFunction<any>>(
+    definition: ImplementableFunctionDefinitionConstructor<D>,
+    args: ImplementableFunctionArguments<D>,
+  ): ImplementableFunctionReturnType<D>[] {
+    return this.functionRegistry.callAll(definition, args, this);
+  }
+
+  /**
    * Looks up a function definition using its name (i.e. the name of the class / constructor), validates the passed
    * arguments, and calls the function implementation.
    * Unlike {@link WorkspaceContext.call}, arguments are fully validated using

--- a/src/function-registry/registry.spec.ts
+++ b/src/function-registry/registry.spec.ts
@@ -210,6 +210,16 @@ describe('FunctionRegistry', () => {
     });
   });
 
+  describe('callAll', () => {
+    it('should call all matching implementations and return results as an array', () => {
+      registry.registerImplementations(MyImpl1, MyImpl2);
+
+      const actualResults = registry.callAll(MyDef, { arg: '🎉' }, {});
+
+      expect(actualResults).toIncludeSameMembers(['1️⃣', '️2️⃣']);
+    });
+  });
+
   describe('validateArguments', () => {
     it('should validate arguments', async () => {
       registry.registerImplementations(MyImpl1);

--- a/src/function-registry/registry.ts
+++ b/src/function-registry/registry.ts
@@ -216,6 +216,25 @@ export class FunctionRegistry<C extends object> {
   }
 
   /**
+   * Invokes all implementations of the given function definition that support the given context, and returns the
+   * results as an array.
+   *
+   * @param definition The constructor of the abstract class defining the function.
+   * @param args Arguments to pass to the function.
+   * @param context The context in which the function is run.
+   * @returns The results of the function calls.
+   */
+  callAll<D extends ImplementableFunction<C, any>>(
+    definition: ImplementableFunctionDefinitionConstructor<D>,
+    args: ImplementableFunctionArguments<D>,
+    context: C,
+  ): ImplementableFunctionReturnType<D>[] {
+    return this.getImplementations(definition, args, context).map((i) =>
+      i._call(context),
+    );
+  }
+
+  /**
    * Validates the arguments for the given function definition.
    * If the arguments are invalid, an {@link InvalidFunctionArgumentError} is thrown.
    * The constructor for the function definition is returned, which can be useful if the definition is referenced using


### PR DESCRIPTION
### 📝 Description of the PR

The function registry currently supports dispatching to a single implementation via call, which throws if zero or more than one implementation matches the context. This adds a `callAll` method that invokes every matching implementation and returns the results as an array, making it possible to collect outputs from multiple implementations of the same function definition. The method is exposed on both `FunctionRegistry` and `WorkspaceContext`, following the same proxy pattern as the existing call method.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.