### PR TITLE
🔖 Prepare v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.23.0 (2026-04-13)
+
+Breaking changes:
+
+- Remove support for Node.js 20.
+
 ## v0.22.2 (2026-03-13)
 
 Chores:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace",
-      "version": "0.22.2",
+      "version": "0.23.0",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "description": "Provides the base functionalities for a workspace: configuration loading and registering functions.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Remove support for Node.js 20.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~