### PR TITLE
✨ Expose configuration internals and support formatted environment values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+Features:
+
+- Allow overriding the file reader used when loading configurations, through the `fileReader` option on `loadWorkspaceConfiguration`, `listProjectPaths`, and `WorkspaceContext.init`.
+- Expose `rawConfigurations` on the `WorkspaceContext`.
+
+Fixes:
+
+- Support loading environment configurations that contain formatted (`$format`) values.
+
+Chores:
+
+- Upgrade dependencies.
+
 ## v0.23.0 (2026-04-13)
 
 Breaking changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "semver": "^7.7.4"
       },
       "devDependencies": {
-        "@swc/core": "^1.15.24",
+        "@swc/core": "^1.15.30",
         "@swc/jest": "^0.2.39",
         "@tsconfig/node22": "^22.0.5",
         "@types/jest": "^30.0.0",
@@ -29,14 +29,14 @@
         "@types/node": "^20.19.39",
         "@types/semver": "^7.7.1",
         "cpy-cli": "^7.0.0",
-        "eslint": "^10.2.0",
+        "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
         "jest": "^30.3.0",
         "jest-extended": "^7.0.0",
         "rimraf": "^6.1.3",
-        "typescript": "^6.0.2",
-        "typescript-eslint": "^8.58.1"
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.58.2"
       },
       "engines": {
         "node": ">=22"
@@ -559,9 +559,9 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -571,9 +571,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -700,25 +700,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -867,9 +881,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1447,9 +1461,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.24.tgz",
-      "integrity": "sha512-5Hj8aNasue7yusUt8LGCUe/AjM7RMAce8ZoyDyiFwx7Al+GbYKL+yE7g4sJk8vEr1dKIkTRARkNIJENc4CjkBQ==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.30.tgz",
+      "integrity": "sha512-R8VQbQY1BZcbIF2p3gjlTCwAQzx1A194ugWfwld5y+WgVVWqVKm7eURGGOVbQVubgKWzidP2agomBbg96rZilQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1465,18 +1479,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.24",
-        "@swc/core-darwin-x64": "1.15.24",
-        "@swc/core-linux-arm-gnueabihf": "1.15.24",
-        "@swc/core-linux-arm64-gnu": "1.15.24",
-        "@swc/core-linux-arm64-musl": "1.15.24",
-        "@swc/core-linux-ppc64-gnu": "1.15.24",
-        "@swc/core-linux-s390x-gnu": "1.15.24",
-        "@swc/core-linux-x64-gnu": "1.15.24",
-        "@swc/core-linux-x64-musl": "1.15.24",
-        "@swc/core-win32-arm64-msvc": "1.15.24",
-        "@swc/core-win32-ia32-msvc": "1.15.24",
-        "@swc/core-win32-x64-msvc": "1.15.24"
+        "@swc/core-darwin-arm64": "1.15.30",
+        "@swc/core-darwin-x64": "1.15.30",
+        "@swc/core-linux-arm-gnueabihf": "1.15.30",
+        "@swc/core-linux-arm64-gnu": "1.15.30",
+        "@swc/core-linux-arm64-musl": "1.15.30",
+        "@swc/core-linux-ppc64-gnu": "1.15.30",
+        "@swc/core-linux-s390x-gnu": "1.15.30",
+        "@swc/core-linux-x64-gnu": "1.15.30",
+        "@swc/core-linux-x64-musl": "1.15.30",
+        "@swc/core-win32-arm64-msvc": "1.15.30",
+        "@swc/core-win32-ia32-msvc": "1.15.30",
+        "@swc/core-win32-x64-msvc": "1.15.30"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -1488,9 +1502,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.24.tgz",
-      "integrity": "sha512-uM5ZGfFXjtvtJ+fe448PVBEbn/CSxS3UAyLj3O9xOqKIWy3S6hPTXSPbszxkSsGDYKi+YFhzAsR4r/eXLxEQ0g==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.30.tgz",
+      "integrity": "sha512-VvpP+vq08HmGYewMWvrdsxh9s2lthz/808zXm8Yu5kaqeR8Yia2b0eYXleHQ3VAjoStUDk6LzTheBW9KXYQdMA==",
       "cpu": [
         "arm64"
       ],
@@ -1505,9 +1519,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.24.tgz",
-      "integrity": "sha512-fMIb/Zfn929pw25VMBhV7Ji2Dl+lCWtUPNdYJQYOke+00E5fcQ9ynxtP8+qhUo/HZc+mYQb1gJxwHM9vty+lXg==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.30.tgz",
+      "integrity": "sha512-WiJA0hiZI3nwQAO6mu5RqigtWGDtth4Hiq6rbZxAaQyhIcqKIg5IoMRc1Y071lrNJn29eEDMC86Rq58xgUxlDg==",
       "cpu": [
         "x64"
       ],
@@ -1522,9 +1536,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.24.tgz",
-      "integrity": "sha512-vOkjsyjjxnoYx3hMEWcGxQrMgnNrRm6WAegBXrN8foHtDAR+zpdhpGF5a4lj1bNPgXAvmysjui8cM1ov/Clkaw==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.30.tgz",
+      "integrity": "sha512-YANuFUo48kIT6plJgCD0keae9HFXfjxsbvsgevqc0hr/07X/p7sAWTFOGYEc2SXcASaK7UvuQqzlbW8pr7R79g==",
       "cpu": [
         "arm"
       ],
@@ -1539,9 +1553,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.24.tgz",
-      "integrity": "sha512-h/oNu+upkXJ6Cicnq7YGVj9PkdfarLCdQa8l/FlHYvfv8CEiMaeeTnpLU7gSBH/rGxosM6Qkfa/J9mThGF9CLA==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.30.tgz",
+      "integrity": "sha512-VndG8jaR4ugY6u+iVOT0Q+d2fZd7sLgjPgN8W/Le+3EbZKl+cRfFxV7Eoz4gfLqhmneZPdcIzf9T3LkgkmqNLg==",
       "cpu": [
         "arm64"
       ],
@@ -1559,9 +1573,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.24.tgz",
-      "integrity": "sha512-ZpF/pRe1guk6sKzQI9D1jAORtjTdNlyeXn9GDz8ophof/w2WhojRblvSDJaGe7rJjcPN8AaOkhwdRUh7q8oYIg==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.30.tgz",
+      "integrity": "sha512-1SYGs2l0Yyyi0pR/P/NKz/x0kqxkoiw+BXeJjLUdecSk/KasncWlJrc6hOvFSgKHOBrzgM5jwuluKtlT8dnrcA==",
       "cpu": [
         "arm64"
       ],
@@ -1579,9 +1593,9 @@
       }
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.24.tgz",
-      "integrity": "sha512-QZEsZfisHTSJlmyChgDFNmKPb3W6Lhbfo/O76HhIngfEdnQNmukS38/VSe1feho+xkV5A5hETyCbx3sALBZKAQ==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.30.tgz",
+      "integrity": "sha512-TXREtiXeRhbfDFbmhnkIsXpKfzbfT73YkV2ZF6w0sfxgjC5zI2ZAbaCOq25qxvegofj2K93DtOpm9RLaBgqR2g==",
       "cpu": [
         "ppc64"
       ],
@@ -1599,9 +1613,9 @@
       }
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.24.tgz",
-      "integrity": "sha512-DLdJKVsJgglqQrJBuoUYNmzm3leI7kUZhLbZGHv42onfKsGf6JDS3+bzCUQfte/XOqDjh/tmmn1DR/CF/tCJFw==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.30.tgz",
+      "integrity": "sha512-DCR2YYeyd6DQE4OuDhImouuNcjXEiEdnn1Y0DyGteugPEDvVuvYk8Xddi+4o2SgWH6jiW8/I+3emZvbep1NC+g==",
       "cpu": [
         "s390x"
       ],
@@ -1619,9 +1633,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.24.tgz",
-      "integrity": "sha512-IpLYfposPA/XLxYOKpRfeccl1p5dDa3+okZDHHTchBkXEaVCnq5MADPmIWwIYj1tudt7hORsEHccG5no6IUQRw==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.30.tgz",
+      "integrity": "sha512-5Pizw3NgfOJ5BJOBK8TIRa59xFW2avESTOBDPTAYwZYa1JNDs+KMF9lUfjJiJLM5HiMs/wPheA9eiT0q9m2AoA==",
       "cpu": [
         "x64"
       ],
@@ -1639,9 +1653,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.24.tgz",
-      "integrity": "sha512-JHy3fMSc0t/EPWgo74+OK5TGr51aElnzqfUPaiRf2qJ/BfX5CUCfMiWVBuhI7qmVMBnk1jTRnL/xZnOSHDPLYg==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.30.tgz",
+      "integrity": "sha512-qyqydP/wyH8alcIP4a2hnGSjHLJjm9H7yDFup+CPy9oTahFgLLwnNcv5UHXqO2Qs3AIND+cls5f/Bb6hqpxdgA==",
       "cpu": [
         "x64"
       ],
@@ -1659,9 +1673,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.24.tgz",
-      "integrity": "sha512-Txj+qUH1z2bUd1P3JvwByfjKFti3cptlAxhWgmunBUUxy/IW3CXLZ6l6Gk4liANadKkU71nIU1X30Z5vpMT3BA==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.30.tgz",
+      "integrity": "sha512-CaQENgDHVGOg1mSF5sQVgvfFHG9kjMor2rkLMLeLOkfZYNj13ppnJ9+lfaBZLZUMMbnlGQnavCJb8PVBUOso7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1676,9 +1690,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.24.tgz",
-      "integrity": "sha512-15D/nl3XwrhFpMv+MADFOiVwv3FvH9j8c6Rf8EXBT3Q5LoMh8YnDnSgPYqw1JzPnksvsBX6QPXLiPqmcR/Z4qQ==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.30.tgz",
+      "integrity": "sha512-30VdLeGk6fugiUs/kUdJ/pAg7z/zpvVbR11RH60jZ0Z42WIeIniYx0rLEWN7h/pKJ3CopqsQ3RsogCAkRKiA2g==",
       "cpu": [
         "ia32"
       ],
@@ -1693,9 +1707,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.24",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.24.tgz",
-      "integrity": "sha512-PR0PlTlPra2JbaDphrOAzm6s0v9rA0F17YzB+XbWD95B4g2cWcZY9LAeTa4xll70VLw9Jr7xBrlohqlQmelMFQ==",
+      "version": "1.15.30",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.30.tgz",
+      "integrity": "sha512-4iObHPR+Q4oDY110EF5SF5eIaaVJNpMdG9C0q3Q92BsJ5y467uHz7sYQhP60WYlLFsLQ1el2YrIPUItUAQGOKg==",
       "cpu": [
         "x64"
       ],
@@ -1937,17 +1951,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
-      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/type-utils": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1960,7 +1974,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.1",
+        "@typescript-eslint/parser": "^8.58.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1976,16 +1990,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
-      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2001,14 +2015,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
-      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.1",
-        "@typescript-eslint/types": "^8.58.1",
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2023,14 +2037,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
-      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1"
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2041,9 +2055,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
-      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2058,15 +2072,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
-      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2083,9 +2097,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
-      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2097,16 +2111,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
-      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.1",
-        "@typescript-eslint/tsconfig-utils": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2125,16 +2139,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
-      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1"
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2149,13 +2163,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
-      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/types": "8.58.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2713,9 +2727,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.18",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
-      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+      "version": "2.10.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+      "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2822,9 +2836,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -3181,9 +3195,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.335",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
-      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3241,18 +3255,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
-      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.4",
-        "@eslint/config-helpers": "^0.5.4",
-        "@eslint/core": "^1.2.0",
-        "@eslint/plugin-kit": "^0.7.0",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -5526,9 +5540,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6326,9 +6340,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6340,16 +6354,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
-      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.1",
-        "@typescript-eslint/parser": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1"
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "semver": "^7.7.4"
   },
   "devDependencies": {
-    "@swc/core": "^1.15.24",
+    "@swc/core": "^1.15.30",
     "@swc/jest": "^0.2.39",
     "@tsconfig/node22": "^22.0.5",
     "@types/jest": "^30.0.0",
@@ -60,13 +60,13 @@
     "@types/node": "^20.19.39",
     "@types/semver": "^7.7.1",
     "cpy-cli": "^7.0.0",
-    "eslint": "^10.2.0",
+    "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "jest": "^30.3.0",
     "jest-extended": "^7.0.0",
     "rimraf": "^6.1.3",
-    "typescript": "^6.0.2",
-    "typescript-eslint": "^8.58.1"
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.58.2"
   }
 }

--- a/src/context/configuration.spec.ts
+++ b/src/context/configuration.spec.ts
@@ -139,6 +139,58 @@ describe('configuration', () => {
       ]);
     });
 
+    it('should load a configuration with an environment containing a formatted value', async () => {
+      const configuration: PartialConfiguration<BaseConfiguration> = {
+        workspace: { name: 'my-workspace' },
+        environments: {
+          dev: {
+            name: 'Dev 🪛',
+            configuration: {
+              secrets: {
+                devSecret: {
+                  value: {
+                    $format: '${ configuration("workspace.name") }',
+                  } as any,
+                },
+              },
+            },
+          },
+        },
+      };
+      await writeConfiguration(tmpDir, './causa.yaml', configuration);
+      const expectedConfiguration = {
+        ...configuration,
+        ...configuration.environments?.dev.configuration,
+      };
+
+      const actualConfiguration = await loadWorkspaceConfiguration(
+        tmpDir,
+        'dev',
+        logger,
+      );
+
+      expect(actualConfiguration).toEqual({
+        configuration: expect.any(ConfigurationReader),
+        rootPath: tmpDir,
+        projectPath: null,
+      });
+      expect(actualConfiguration.configuration.get({ unsafe: true })).toEqual(
+        expectedConfiguration,
+      );
+      expect(actualConfiguration.configuration.rawConfigurations).toEqual([
+        {
+          sourceType: ConfigurationReaderSourceType.File,
+          source: join(tmpDir, 'causa.yaml'),
+          configuration: configuration,
+        },
+        {
+          sourceType: WorkspaceConfigurationSourceType.Environment,
+          source: 'dev',
+          configuration: configuration.environments?.dev.configuration,
+        },
+      ]);
+    });
+
     it('should load several files and infer the project path', async () => {
       const workspaceConfiguration: PartialConfiguration<BaseConfiguration> = {
         workspace: { name: 'my-workspace' },

--- a/src/context/configuration.spec.ts
+++ b/src/context/configuration.spec.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { mkdtemp, rm, symlink } from 'fs/promises';
 import 'jest-extended';
 import { tmpdir } from 'os';
@@ -9,6 +10,7 @@ import {
   ConfigurationValueNotFoundError,
   type PartialConfiguration,
 } from '../configuration/index.js';
+import type { FileReader } from '../file-utils.js';
 import type { BaseConfiguration } from './base-configuration.js';
 import {
   WorkspaceConfigurationSourceType,
@@ -238,6 +240,29 @@ describe('configuration', () => {
       ]);
     });
 
+    it('should use the provided file reader to load configurations', async () => {
+      await writeConfiguration(tmpDir, './causa.yaml', {
+        workspace: { name: 'on-disk' },
+      });
+      const fileReader = jest
+        .fn<FileReader>()
+        .mockResolvedValue('workspace:\n  name: from-reader\n');
+
+      const actualConfiguration = await loadWorkspaceConfiguration(
+        tmpDir,
+        null,
+        logger,
+        { fileReader },
+      );
+
+      expect(actualConfiguration.configuration.get()).toEqual({
+        workspace: { name: 'from-reader' },
+      });
+      expect(fileReader).toHaveBeenCalledExactlyOnceWith(
+        join(tmpDir, 'causa.yaml'),
+      );
+    });
+
     it('should throw when the workspace is defined in two different places', async () => {
       await writeConfiguration(tmpDir, './causa.yaml', {
         workspace: { name: 'my-workspace' },
@@ -298,6 +323,24 @@ describe('configuration', () => {
       const actualPaths = await listProjectPaths(tmpDir);
 
       expect(actualPaths).toEqual([tmpDir]);
+    });
+
+    it('should use the provided file reader when loading configurations', async () => {
+      await writeConfiguration(tmpDir, './causa.yaml', {
+        workspace: { name: 'my-workspace' },
+      });
+      const fileReader = jest
+        .fn<(source: string) => Promise<string>>()
+        .mockResolvedValue(
+          'project:\n  name: from-reader\n  type: "🐍"\n  language: "🇫🇷"\n',
+        );
+
+      const actualPaths = await listProjectPaths(tmpDir, { fileReader });
+
+      expect(actualPaths).toEqual([tmpDir]);
+      expect(fileReader).toHaveBeenCalledExactlyOnceWith(
+        join(tmpDir, 'causa.yaml'),
+      );
     });
 
     it('should return several paths and ignore symbolic links', async () => {

--- a/src/context/configuration.ts
+++ b/src/context/configuration.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'fs/promises';
 import { globby } from 'globby';
 import { load } from 'js-yaml';
 import { get } from 'lodash-es';
@@ -13,6 +12,7 @@ import {
   type RawConfiguration,
 } from '../configuration/index.js';
 import type { BaseConfiguration } from './base-configuration.js';
+import { DEFAULT_FILE_READER, type FileReaderOption } from '../file-utils.js';
 import { InvalidWorkspaceConfigurationFilesError } from './errors.js';
 
 /**
@@ -51,12 +51,15 @@ export enum WorkspaceConfigurationSourceType {
  * Creates a {@link RawConfiguration} from a file.
  *
  * @param source The path to the configuration file.
+ * @param options Options for reading the file.
  * @returns The {@link RawConfiguration}.
  */
-export async function makeFileConfiguration<T = any>(
+async function makeFileConfiguration<T = any>(
   source: string,
+  options: FileReaderOption = {},
 ): Promise<RawConfiguration<T>> {
-  const content = await readFile(source, { encoding: 'utf-8' });
+  const fileReader = options.fileReader ?? DEFAULT_FILE_READER;
+  const content = await fileReader(source);
   const configuration = load(content) as any;
   return {
     sourceType: ConfigurationReaderSourceType.File,
@@ -71,12 +74,12 @@ export async function makeFileConfiguration<T = any>(
  * In a single folder, files are returned in descending alphabetical order.
  *
  * @param basePath The path from which the search is started, then moving up the folder hierarchy.
- * @param fileRegexps The list of regular expressions from which a filename should produce at least one match to be
- *   considered a configuration file.
+ * @param options Options for loading the configurations.
  * @returns The list of {@link RawConfiguration}s.
  */
 async function loadRawConfigurations<T extends object>(
   basePath: string,
+  options: FileReaderOption = {},
 ): Promise<RawConfiguration<T>[]> {
   const directories = [basePath];
 
@@ -98,7 +101,7 @@ async function loadRawConfigurations<T extends object>(
 
       return await Promise.all(
         configurationFiles.map((fileName) =>
-          makeFileConfiguration(join(path, fileName)),
+          makeFileConfiguration(join(path, fileName), options),
         ),
       );
     }),
@@ -111,10 +114,12 @@ async function loadRawConfigurations<T extends object>(
  * Loads all the file configurations located in a folder or its subfolders.
  *
  * @param rootPath The root path from which configuration files are searched recursively.
+ * @param options Options for loading the configurations.
  * @returns The list of {@link RawConfiguration}s loaded from the root path and its subdirectories.
  */
 async function loadRawConfigurationsFromRoot<T extends object>(
   rootPath: string,
+  options: FileReaderOption = {},
 ): Promise<RawConfiguration<T>[]> {
   const paths = await globby(RECURSIVE_CONFIGURATION_PATTERNS, {
     gitignore: true,
@@ -123,7 +128,7 @@ async function loadRawConfigurationsFromRoot<T extends object>(
   });
 
   return await Promise.all(
-    paths.map((path) => makeFileConfiguration(join(rootPath, path))),
+    paths.map((path) => makeFileConfiguration(join(rootPath, path), options)),
   );
 }
 
@@ -201,19 +206,23 @@ export type LoadedWorkspaceConfiguration = {
  * @param workingDirectory The working directory from which the configuration should be loaded.
  * @param environmentId The ID of the environment for which the configuration should be set up. Can be `null`.
  * @param logger The logger to use.
+ * @param options Options for loading the configurations.
  * @returns The configuration, along with the inferred workspace and project paths.
  */
 export async function loadWorkspaceConfiguration(
   workingDirectory: string,
   environmentId: string | null,
   logger: Logger,
+  options: FileReaderOption = {},
 ): Promise<LoadedWorkspaceConfiguration> {
   logger.debug(
     `🔧 Looking for configurations starting from working directory '${workingDirectory}'.`,
   );
 
-  const configurations =
-    await loadRawConfigurations<BaseConfiguration>(workingDirectory);
+  const configurations = await loadRawConfigurations<BaseConfiguration>(
+    workingDirectory,
+    options,
+  );
   if (configurations.length === 0) {
     throw new InvalidWorkspaceConfigurationFilesError(
       `No configuration file was found starting at working directory '${workingDirectory}'.`,
@@ -263,10 +272,14 @@ export async function loadWorkspaceConfiguration(
  * containing a project configuration.
  *
  * @param rootPath The root path from which configuration files are searched recursively.
+ * @param options Options for loading the configurations.
  * @returns The list of directory paths containing a project configuration.
  */
-export async function listProjectPaths(rootPath: string): Promise<string[]> {
-  const configurations = await loadRawConfigurationsFromRoot(rootPath);
+export async function listProjectPaths(
+  rootPath: string,
+  options: FileReaderOption = {},
+): Promise<string[]> {
+  const configurations = await loadRawConfigurationsFromRoot(rootPath, options);
   return findPathInConfigurations(configurations, 'project.name', {
     allowMultiple: true,
   });

--- a/src/context/configuration.ts
+++ b/src/context/configuration.ts
@@ -229,6 +229,7 @@ export async function loadWorkspaceConfiguration(
 
     const { configuration: envConf } = configuration.getOrThrow(
       `environments.${environmentId}`,
+      { unsafe: true },
     );
 
     if (envConf) {

--- a/src/context/context.spec.ts
+++ b/src/context/context.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import {
+  ConfigurationReaderSourceType,
   ConfigurationValueNotFoundError,
   type PartialConfiguration,
 } from '../configuration/index.js';
@@ -21,6 +22,7 @@ import {
   SecretBackendNotFoundError,
   SecretBackendNotSpecifiedError,
 } from './errors.js';
+import { WorkspaceConfigurationSourceType } from './configuration.js';
 import { writeConfiguration } from './utils.test.js';
 
 describe('WorkspaceContext', () => {
@@ -86,6 +88,23 @@ describe('WorkspaceContext', () => {
         },
         myService: { myValue: '🎉' },
       });
+      expect(actualContext.rawConfigurations).toEqual([
+        {
+          sourceType: ConfigurationReaderSourceType.File,
+          source: join(tmpDir, 'causa.yaml'),
+          configuration: workspaceConfiguration,
+        },
+        {
+          sourceType: ConfigurationReaderSourceType.File,
+          source: join(tmpDir, 'project', 'causa.yaml'),
+          configuration: projectConfiguration,
+        },
+        {
+          sourceType: WorkspaceConfigurationSourceType.Environment,
+          source: 'dev',
+          configuration: workspaceConfiguration.environments?.dev.configuration,
+        },
+      ]);
       expect(actualExternalPaths).toBeEmpty();
     });
 

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -6,6 +6,7 @@ import type {
   GetFieldType,
   RawConfiguration,
 } from '../configuration/index.js';
+import type { FileReaderOption } from '../file-utils.js';
 import {
   FunctionRegistry,
   type ImplementableFunctionArguments,
@@ -65,7 +66,7 @@ export type WorkspaceContextOptions = {
    * The logger to use. Defaults to `pino()`.
    */
   logger?: Logger;
-};
+} & FileReaderOption;
 
 /**
  * Options for {@link WorkspaceContext.getAndRender} and related methods.
@@ -187,10 +188,11 @@ export class WorkspaceContext {
    * Looks for Causa configuration files from the workspace root directory, and returns the list of directory paths that
    * contain a project
    *
+   * @param options Options for loading the configurations.
    * @returns The list of paths.
    */
-  async listProjectPaths(): Promise<string[]> {
-    return await listProjectPaths(this.rootPath);
+  async listProjectPaths(options: FileReaderOption = {}): Promise<string[]> {
+    return await listProjectPaths(this.rootPath, options);
   }
 
   /**
@@ -528,7 +530,9 @@ export class WorkspaceContext {
     const environment = options.environment ?? null;
 
     const { configuration, rootPath, projectPath } =
-      await loadWorkspaceConfiguration(workingDirectory, environment, logger);
+      await loadWorkspaceConfiguration(workingDirectory, environment, logger, {
+        fileReader: options.fileReader,
+      });
 
     const functionRegistry = new FunctionRegistry(WorkspaceFunction);
 

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -4,6 +4,7 @@ import { type Logger, pino } from 'pino';
 import type {
   ConfigurationGetOptions,
   GetFieldType,
+  RawConfiguration,
 } from '../configuration/index.js';
 import {
   FunctionRegistry,
@@ -113,6 +114,13 @@ export class WorkspaceContext {
     readonly logger: Logger,
   ) {
     this.serviceCache = new ServiceCache(this);
+  }
+
+  /**
+   * The list of {@link RawConfiguration}s that were merged to build the workspace configuration.
+   */
+  get rawConfigurations(): RawConfiguration<BaseConfiguration>[] {
+    return this.configuration.rawConfigurations;
   }
 
   /**

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -1,6 +1,29 @@
+import { readFile } from 'fs/promises';
 import { type Options, globby } from 'globby';
 import { template } from 'lodash-es';
 import { join } from 'path';
+
+/**
+ * A function that reads the content of a file.
+ */
+export type FileReader = (source: string) => Promise<string>;
+
+/**
+ * The default {@link FileReader}, which reads files from disk using UTF-8 encoding.
+ */
+export const DEFAULT_FILE_READER: FileReader = (source) =>
+  readFile(source, { encoding: 'utf-8' });
+
+/**
+ * An option object accepting a custom {@link FileReader}.
+ */
+export type FileReaderOption = {
+  /**
+   * The {@link FileReader} used to read file contents.
+   * Defaults to {@link DEFAULT_FILE_READER}.
+   */
+  fileReader?: FileReader;
+};
 
 /**
  * A file matched by {@link listFilesAndFormat}.


### PR DESCRIPTION
### 📝 Description of the PR

This branch bundles several improvements to how workspace configurations are loaded and exposed.

The main additions are around extensibility and visibility. The `fileReader` option now flows through `loadWorkspaceConfiguration`, `listProjectPaths`, and `WorkspaceContext.init`, letting callers swap the on-disk YAML reader for a custom one — useful when configurations come from an in-memory source (e.g. for the VSCode extension "dirty" documents). The `WorkspaceContext` also exposes its underlying `rawConfigurations`, so callers can inspect the individual configuration sources (files, environment overlays, processor outputs) that were merged to produce the effective configuration.

On the fix side, loading an environment whose configuration contains a `$format` template no longer throws an `UnformattedTemplateValueError` during `loadWorkspaceConfiguration`. The environment sub-configuration is now extracted with `unsafe: true`, since it is simply re-merged into the reader rather than consumed as a value — rendering still happens at read time as before.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.