### PR TITLE
🔖 Prepare v0.25.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.25.0-beta.1 (2026-05-14)
+
 Breaking changes:
 
 - The execution context is now exposed as the `_context` property on `ImplementableFunction` instances, rather than being passed as an argument to `_call` and `_supports`. Implementations should access it via `this._context`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace",
-  "version": "0.24.1",
+  "version": "0.25.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace",
-      "version": "0.24.1",
+      "version": "0.25.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace",
-  "version": "0.24.1",
+  "version": "0.25.0-beta.1",
   "description": "Provides the base functionalities for a workspace: configuration loading and registering functions.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- The execution context is now exposed as the `_context` property on `ImplementableFunction` instances, rather than being passed as an argument to `_call` and `_supports`. Implementations should access it via `this._context`.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~