### PR TITLE
🔖 Prepare v0.25.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.25.0-beta.2 (2026-05-14)
+
+Breaking changes:
+
+- Remove the `context` argument from `callDeferred`.
+
 ## v0.25.0-beta.1 (2026-05-14)
 
 Breaking changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace",
-  "version": "0.25.0-beta.1",
+  "version": "0.25.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace",
-      "version": "0.25.0-beta.1",
+      "version": "0.25.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace",
-  "version": "0.25.0-beta.1",
+  "version": "0.25.0-beta.2",
   "description": "Provides the base functionalities for a workspace: configuration loading and registering functions.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Remove the `context` argument from `callDeferred`.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~