### PR TITLE
♻️ Replace js-yaml with yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Chores:
+
+- Replace the `js-yaml` dependency with `yaml`.
+
 ## v0.25.0-beta.2 (2026-05-14)
 
 Breaking changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,18 +13,17 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "globby": "^16.2.0",
-        "js-yaml": "^4.1.1",
         "lodash-es": "^4.18.1",
         "pino": "^10.3.1",
         "resolve-package-path": "^4.0.3",
-        "semver": "^7.8.0"
+        "semver": "^7.8.0",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@swc/core": "^1.15.33",
         "@swc/jest": "^0.2.39",
         "@tsconfig/node22": "^22.0.5",
         "@types/jest": "^30.0.0",
-        "@types/js-yaml": "^4.0.9",
         "@types/lodash-es": "^4.17.12",
         "@types/node": "^20.19.41",
         "@types/semver": "^7.7.1",
@@ -1874,13 +1873,6 @@
         "pretty-format": "^30.0.0"
       }
     },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2592,12 +2584,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -4793,18 +4779,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6682,6 +6656,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/node": "^20.19.41",
         "@types/semver": "^7.7.1",
         "cpy-cli": "^7.0.0",
-        "eslint": "^10.3.0",
+        "eslint": "^10.4.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
         "jest": "^30.4.2",
@@ -649,9 +649,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -799,16 +799,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -821,20 +811,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -2585,6 +2561,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -2714,9 +2700,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.10.30",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
+      "integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2823,9 +2809,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -3182,9 +3168,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.355",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
-      "integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
+      "version": "1.5.357",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+      "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
       "dev": true,
       "license": "ISC"
     },
@@ -3242,16 +3228,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
@@ -4779,6 +4765,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4888,9 +4888,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.1.tgz",
-      "integrity": "sha512-GEw0GLL7YUUA6nv21IsCvVjtI5Ejn84sjbdfQ9KxdbqEVOk1PZh7xejn01EEiniKw+dBeCfim+8MGeuvVuE2BA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.2.tgz",
+      "integrity": "sha512-S3kmBrptp3yRTm83NUcHy9g1vbwiWMzI8WvY22+koBJ6zkRteLnedBL2VX0MIAGwx2yiyxX4J85pceZyQ6ffgg==",
       "license": "MIT"
     },
     "node_modules/lines-and-columns": {
@@ -5762,9 +5762,9 @@
       }
     },
     "node_modules/rimraf/node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6221,9 +6221,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.1.0.tgz",
-      "integrity": "sha512-Bw6h2iBDt16v6iHLChBIoVYU8CBo9GPsW8TG7h1hRVhqKhIkH6N8qkxNSmiOZTKsCLPbtWG4ViWLkU6KeKXpig==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
       "license": "MIT",
       "dependencies": {
         "real-require": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -44,18 +44,17 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "globby": "^16.2.0",
-    "js-yaml": "^4.1.1",
     "lodash-es": "^4.18.1",
     "pino": "^10.3.1",
     "resolve-package-path": "^4.0.3",
-    "semver": "^7.8.0"
+    "semver": "^7.8.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@swc/core": "^1.15.33",
     "@swc/jest": "^0.2.39",
     "@tsconfig/node22": "^22.0.5",
     "@types/jest": "^30.0.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^20.19.41",
     "@types/semver": "^7.7.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^20.19.41",
     "@types/semver": "^7.7.1",
     "cpy-cli": "^7.0.0",
-    "eslint": "^10.3.0",
+    "eslint": "^10.4.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "jest": "^30.4.2",

--- a/src/context/configuration.ts
+++ b/src/context/configuration.ts
@@ -1,5 +1,5 @@
 import { globby } from 'globby';
-import { load } from 'js-yaml';
+import { parse } from 'yaml';
 import { get } from 'lodash-es';
 import { dirname, join } from 'path';
 import type { Logger } from 'pino';
@@ -60,7 +60,7 @@ async function makeFileConfiguration<T = any>(
 ): Promise<RawConfiguration<T>> {
   const fileReader = options.fileReader ?? DEFAULT_FILE_READER;
   const content = await fileReader(source);
-  const configuration = load(content) as any;
+  const configuration = parse(content);
   return {
     sourceType: ConfigurationReaderSourceType.File,
     source,

--- a/src/context/context.spec.ts
+++ b/src/context/context.spec.ts
@@ -29,7 +29,7 @@ describe('WorkspaceContext', () => {
   let tmpDir: string;
 
   beforeEach(async () => {
-    // Creating the temporary directory outside of the repository, ensures that module resolution cannot find 'js-yaml'
+    // Creating the temporary directory outside of the repository, ensures that module resolution cannot find 'yaml'
     // when starting from the workspace root path.
     tmpDir = resolve(await mkdtemp(join(tmpdir(), 'causa-tests-')));
   });
@@ -366,7 +366,7 @@ describe('WorkspaceContext', () => {
         workspace: { name: 'my-workspace' },
         causa: {
           modules: {
-            'js-yaml': 'file:/some/path',
+            yaml: 'file:/some/path',
           },
         },
         myFunction: { returnValue: '🎉' },
@@ -377,7 +377,7 @@ describe('WorkspaceContext', () => {
         workingDirectory: tmpDir,
       });
 
-      // This should not be a `ModuleVersionError`. It should be a `TypeError` because `js-yaml` could be loaded but is
+      // This should not be a `ModuleVersionError`. It should be a `TypeError` because `yaml` could be loaded but is
       // not a valid Causa module.
       await expect(actualPromise).rejects.toThrow(TypeError);
     });
@@ -389,10 +389,10 @@ describe('WorkspaceContext', () => {
         workspace: { name: 'my-workspace' },
         causa: {
           // This is obviously not a valid workspace module, but the point is to make the version check fail, which
-          // occurs before the actual import. `js-yaml` is a dependency of this module and a newer version is used.
+          // occurs before the actual import. `yaml` is a dependency of this module and a newer version is used.
           // Also, this ensures modules are resolved from the source file path rather than the workspace root.
           // (See the initialization of `tmpDir`.)
-          modules: { 'js-yaml': '^3.2.0' },
+          modules: { yaml: '^1.2.0' },
         },
         myFunction: { returnValue: '🎉' },
       };

--- a/src/context/utils.test.ts
+++ b/src/context/utils.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from 'fs/promises';
-import { dump } from 'js-yaml';
+import { stringify } from 'yaml';
 import { dirname, join } from 'path';
 import type { PartialConfiguration } from '../configuration/index.js';
 import type { BaseConfiguration } from './base-configuration.js';
@@ -14,6 +14,6 @@ export async function writeConfiguration(
 
   await mkdir(dirPath, { recursive: true });
 
-  const confStr = dump(configuration);
+  const confStr = stringify(configuration);
   await writeFile(fullPath, confStr);
 }


### PR DESCRIPTION
### 📝 Description of the PR

Swap the `js-yaml` dependency for the `yaml` package, which is actively maintained, ships with its own TypeScript types, and removes the need for the separate `@types/js-yaml` dev dependency. Also, `yaml` will be needed for `@causa/workspace-core` because it provides lower-level parsing and writing.
Configuration loading now uses `parse` from `yaml`, and the test helper uses `stringify`.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- ~📝 Documentation has been updated.~