### PR TITLE
🐛 Prefer deduplication when installing Causa modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Prefer deduplication when installing Causa modules.
+
 ## v1.0.0 (2026-06-09)
 
 This release includes all the changes from the `v0.25.0-beta.*` versions.

--- a/src/initialization/installation.spec.ts
+++ b/src/initialization/installation.spec.ts
@@ -62,6 +62,25 @@ describe('installation', () => {
     ).resolves.toBeTruthy();
   });
 
+  it('should prefer deduplication when installing modules', async () => {
+    await setUpCausaFolder(
+      tmpDir,
+      { '@causa/cli': '*', '@causa/workspace-core': '0.34.0' },
+      logger,
+    );
+
+    const actualCliPackageFile = await readFile(
+      join(tmpDir, '.causa', 'node_modules', '@causa', 'cli', 'package.json'),
+    );
+    const actualCliVersion = JSON.parse(
+      actualCliPackageFile.toString(),
+    ).version;
+    // Without deduplication, the latest `@causa/cli` (`>= 1.0.0`) would be installed at the top level, with an older
+    // version nested in `@causa/workspace-core`.
+    const actualCliMajor = Number(actualCliVersion.split('.')[0]);
+    expect(actualCliMajor).toBeLessThan(1);
+  }, 60000);
+
   it('should throw an error when installing the modules fails', async () => {
     const actualPromise = setUpCausaFolder(
       tmpDir,

--- a/src/initialization/installation.ts
+++ b/src/initialization/installation.ts
@@ -80,7 +80,7 @@ async function installModules(
   logger.debug(`➕ Installing node modules in '${causaFolder}'.`);
 
   await new Promise<void>((resolve, reject) => {
-    const child = exec('npm install --quiet', {
+    const child = exec('npm install --quiet --prefer-dedupe', {
       cwd: causaFolder,
     });
     child.stderr?.pipe(process.stderr);


### PR DESCRIPTION
### 📝 Description of the PR

Causa modules are now installed with deduplication preferred, so that a single shared version is resolved whenever multiple required modules have overlapping dependency ranges. Previously, installation could pull in duplicate, higher versions of transitive dependencies that did not match the constraints of the modules requesting them, leading to inconsistent module trees.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.
