### PR TITLE
🔖 Prepare v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.0.2 (2026-06-26)
+
 Fixes:
 
 - Ignore file system access errors (e.g. permission errors) when walking the folder hierarchy searching for configurations. Directories that cannot be listed are now skipped instead of failing the entire load.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provides the base functionalities for a workspace: configuration loading and registering functions.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes:

- Ignore file system access errors (e.g. permission errors) when walking the folder hierarchy searching for configurations. Directories that cannot be listed are now skipped instead of failing the entire load.